### PR TITLE
fix MultiIndex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Version history
 - 1.2.1: Added setup requirements
 - 1.3.0: Improved OTU file header. Split the log file into a debug and progress log.
 - 1.4.0: Made an improvement to the Levenshtein-based genetic dissimilarity metric.
+- 1.4.1: Account for pandas API change to ``MultiIndex``
 
 To-do
 -----

--- a/dbotu.py
+++ b/dbotu.py
@@ -310,7 +310,7 @@ def read_sequence_table(fn):
     df = pd.read_table(fn, dtype={0: str}, header=0) # read in all columns as strings
 
     # BIOM format things will complain here
-    if type(df.index) is pd.indexes.multi.MultiIndex:
+    if type(df.index) is pd.MultiIndex:
         warnings.warn('Table was parsed with unusual indexes. Does this table comply with the tab-separated format?', RuntimeWarning)
 
     # TSV formats will complain here

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst') as f:
     readme=f.read()
 
 setup(name='dbotu',
-    version='1.4.0',
+    version='1.4.1',
     description='Distribution-based OTU calling',
     long_description=readme,
     author='Scott Olesen',


### PR DESCRIPTION
As per #4, it looks like the latest Pandas release (0.20) change the apparent location of the `MultiIndex` class. It previously used to be at `pandas.MultiIndex` as well as `pandas.indexes.multi.MultiIndex`, but now it's only at the former and not at the latter.