### PR TITLE
Add function to write output fasta with representative seqs

### DIFF
--- a/dbotu.py
+++ b/dbotu.py
@@ -291,6 +291,17 @@ class DBCaller:
         for otu in sorted_otus:
             print(otu.name, *self.membership[otu.name], sep='\t', file=output)
 
+    def write_fasta(self, output):
+        '''
+        Write the output fasta with dbOTU representative sequences.
+
+        output: filehandle
+
+        returns: nothing
+        '''
+        for otu in self.otus:
+            rec = ['>', otu.name, '\n', otu.sequence]
+            print(*rec, sep='', file=output)
 
 def read_sequence_table(fn):
     '''


### PR DESCRIPTION
I added a function to the DBCaller class to write a fasta file with the representative sequences.

I need this to incorporate dbOTU into qiime 2, though it might also make sense to give users the option to write a fasta file from the command line (in addition to the membership file). Happy to add this as well, or you can!