### PR TITLE
Fix conda install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ dbotu3 is also on conda_ and can be installed as follows:
 
 .. code-block::
 
-    conda install -c cduvallet dbotu
+    conda install -c cduvallet -c conda-forge dbotu
 
 For `QIIME 2`_ users, dbotu3 is also available as a plugin_.
 


### PR DESCRIPTION
`conda install` fails if you don't add the conda-forge channel (which is needed for python levenshtein). Not sure why this happens, but adding the channel explicitly fixes install issues.